### PR TITLE
Add WebGL2 RC boat prototype with water sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# RC Boat Trials
+
+A prototype WebGL2 RC boat time trial built around a GPU-driven water simulation. The project follows the included game design document and uses a fixed-timestep loop, Evan Wallace–style height-field water, and simple arcade boat physics.
+
+## Features
+
+- GPU height-field water simulation with Gaussian drop impulses and dynamic normal map.
+- Water surface shading with Fresnel blend, simple environment lighting, and procedural track tinting.
+- Arcade boat physics with buoyancy, thrust, lateral drag, and wake-induced ripples.
+- Hard-coded oval time-trial track with checkpoint progression and lap timing HUD.
+- Keyboard controls (W/S throttle, A/D steering, R reset) with optional mouse ripples.
+
+## Getting Started
+
+The project is dependency free and served as ES modules. Any static file server can be used for development:
+
+```bash
+npx http-server .
+# or
+python -m http.server
+```
+
+Open `http://localhost:8080` (or the port reported by your server) in a WebGL2-capable browser.
+
+## Controls
+
+- **Throttle:** `W` / `↑`
+- **Brake/Reverse:** `S` / `↓`
+- **Steer:** `A` / `D` or `←` / `→`
+- **Reset Boat:** `R`
+- **Water Ripple:** Left mouse click
+
+## Notes
+
+- The prototype targets WebGL2. A compatibility notice is shown if WebGL2 is unavailable.
+- Performance scales with the GPU. The default water resolution is 256×256 and can be tuned in `src/core/tuning.js`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RC Boat Trials</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0a1118;
+        color: #ffffff;
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      }
+
+      #gl-canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      #overlay-root {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+      }
+
+      .notice {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        padding: 1.5rem 2rem;
+        background: rgba(10, 17, 24, 0.85);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 8px;
+        text-align: center;
+        max-width: 420px;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="gl-canvas"></canvas>
+    <div id="overlay-root"></div>
+    <div id="compatibility-notice" class="notice" style="display: none"></div>
+    <script type="module" src="./src/core/main.js"></script>
+  </body>
+</html>

--- a/shaders/boat.frag
+++ b/shaders/boat.frag
@@ -1,0 +1,21 @@
+precision highp float;
+
+varying vec3 vWorldPos;
+varying vec3 vNormal;
+
+uniform vec3 uCameraPos;
+uniform vec3 uLightDir;
+uniform vec3 uBaseColor;
+
+void main() {
+  vec3 normal = normalize(vNormal);
+  vec3 lightDir = normalize(uLightDir);
+  vec3 viewDir = normalize(uCameraPos - vWorldPos);
+
+  float diffuse = max(dot(normal, lightDir), 0.0);
+  vec3 halfVec = normalize(lightDir + viewDir);
+  float spec = pow(max(dot(normal, halfVec), 0.0), 32.0);
+
+  vec3 color = uBaseColor * (0.25 + diffuse * 0.75) + vec3(0.9, 0.9, 0.8) * spec * 0.4;
+  gl_FragColor = vec4(color, 1.0);
+}

--- a/shaders/boat.vert
+++ b/shaders/boat.vert
@@ -1,0 +1,16 @@
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+
+uniform mat4 uModel;
+uniform mat4 uViewProjection;
+uniform mat3 uNormalMatrix;
+
+varying vec3 vWorldPos;
+varying vec3 vNormal;
+
+void main() {
+  vec4 worldPos = uModel * vec4(aPosition, 1.0);
+  vWorldPos = worldPos.xyz;
+  vNormal = normalize(uNormalMatrix * aNormal);
+  gl_Position = uViewProjection * worldPos;
+}

--- a/shaders/probe.frag
+++ b/shaders/probe.frag
@@ -1,0 +1,18 @@
+precision highp float;
+
+varying vec2 vUv;
+
+uniform sampler2D uHeight;
+uniform sampler2D uNormal;
+uniform vec2 uProbeCenter;
+
+vec2 xzToUv(vec2 xz) {
+  return xz * 0.5 + 0.5;
+}
+
+void main() {
+  vec2 uv = xzToUv(uProbeCenter);
+  float h = texture2D(uHeight, uv).r;
+  vec3 n = texture2D(uNormal, uv).xyz * 2.0 - 1.0;
+  gl_FragColor = vec4(h, n.x * 0.5 + 0.5, n.z * 0.5 + 0.5, 1.0);
+}

--- a/shaders/water_drop.frag
+++ b/shaders/water_drop.frag
@@ -1,0 +1,16 @@
+precision highp float;
+
+varying vec2 vUv;
+
+uniform sampler2D uPrev;
+uniform vec2 uCenter;
+uniform float uRadius;
+uniform float uStrength;
+
+void main() {
+  vec4 prev = texture2D(uPrev, vUv);
+  float dist = distance(vUv, uCenter);
+  float influence = exp(-pow(dist / max(uRadius, 1e-4), 2.0));
+  prev.r += influence * uStrength;
+  gl_FragColor = prev;
+}

--- a/shaders/water_normal.frag
+++ b/shaders/water_normal.frag
@@ -1,0 +1,15 @@
+precision highp float;
+
+varying vec2 vUv;
+
+uniform sampler2D uHeight;
+uniform vec2 uTexel;
+
+void main() {
+  float hL = texture2D(uHeight, vUv - vec2(uTexel.x, 0.0)).r;
+  float hR = texture2D(uHeight, vUv + vec2(uTexel.x, 0.0)).r;
+  float hD = texture2D(uHeight, vUv - vec2(0.0, uTexel.y)).r;
+  float hU = texture2D(uHeight, vUv + vec2(0.0, uTexel.y)).r;
+  vec3 n = normalize(vec3((hR - hL) * 0.5, 1.0, (hU - hD) * 0.5));
+  gl_FragColor = vec4(n * 0.5 + 0.5, 1.0);
+}

--- a/shaders/water_surface.frag
+++ b/shaders/water_surface.frag
@@ -1,0 +1,40 @@
+precision highp float;
+
+varying vec2 vUv;
+varying vec3 vWorldPos;
+
+uniform sampler2D uHeight;
+uniform sampler2D uNormal;
+uniform sampler2D uTrackMask;
+
+uniform vec3 uCameraPos;
+uniform vec3 uSunDir;
+uniform vec3 uSkyColor;
+uniform vec3 uWaterDeepColor;
+uniform vec3 uWaterShallowColor;
+
+void main() {
+  float height = texture2D(uHeight, vUv).r;
+  vec3 normal = texture2D(uNormal, vUv).xyz * 2.0 - 1.0;
+  vec3 worldPos = vec3(vWorldPos.x, height, vWorldPos.z);
+
+  vec3 viewDir = normalize(uCameraPos - worldPos);
+  vec3 lightDir = normalize(uSunDir);
+
+  float fresnel = pow(1.0 - clamp(dot(normal, viewDir), 0.0, 1.0), 3.0);
+  float diffuse = max(dot(normal, lightDir), 0.0);
+  vec3 halfVec = normalize(lightDir + viewDir);
+  float spec = pow(max(dot(normal, halfVec), 0.0), 64.0);
+
+  float depthFactor = clamp((height + 0.1) * 4.0, 0.0, 1.0);
+  vec3 baseColor = mix(uWaterDeepColor, uWaterShallowColor, depthFactor);
+  float trackMask = texture2D(uTrackMask, vUv).r;
+  baseColor = mix(baseColor, baseColor * 0.6, trackMask);
+
+  vec3 reflection = uSkyColor;
+  vec3 refraction = baseColor + diffuse * vec3(0.18) + spec * vec3(0.45);
+  vec3 color = mix(refraction, reflection, fresnel);
+  color = color * 0.9 + vec3(0.03, 0.04, 0.05);
+
+  gl_FragColor = vec4(color, 1.0);
+}

--- a/shaders/water_surface.vert
+++ b/shaders/water_surface.vert
@@ -1,0 +1,14 @@
+attribute vec2 aPosition;
+attribute vec2 aUV;
+
+uniform mat4 uViewProjection;
+
+varying vec2 vUv;
+varying vec3 vWorldPos;
+
+void main() {
+  vUv = aUV;
+  vec3 worldPos = vec3(aPosition.x, 0.0, aPosition.y);
+  vWorldPos = worldPos;
+  gl_Position = uViewProjection * vec4(worldPos, 1.0);
+}

--- a/shaders/water_update.frag
+++ b/shaders/water_update.frag
@@ -1,0 +1,25 @@
+precision highp float;
+
+varying vec2 vUv;
+
+uniform sampler2D uPrev;
+uniform vec2 uTexel;
+uniform float uWaveSpeed;
+uniform float uDamping;
+uniform float uDt;
+
+void main() {
+  vec4 prev = texture2D(uPrev, vUv);
+  float h = prev.r;
+  float v = prev.g;
+
+  float hL = texture2D(uPrev, vUv - vec2(uTexel.x, 0.0)).r;
+  float hR = texture2D(uPrev, vUv + vec2(uTexel.x, 0.0)).r;
+  float hD = texture2D(uPrev, vUv - vec2(0.0, uTexel.y)).r;
+  float hU = texture2D(uPrev, vUv + vec2(0.0, uTexel.y)).r;
+
+  float lap = (hL + hR + hD + hU - 4.0 * h);
+  v += (uWaveSpeed * uWaveSpeed * lap - uDamping * v) * uDt;
+  h += v * uDt;
+  gl_FragColor = vec4(h, v, 0.0, 1.0);
+}

--- a/src/core/gl-utils.js
+++ b/src/core/gl-utils.js
@@ -1,0 +1,129 @@
+const FULLSCREEN_VERT = `
+attribute vec2 aPosition;
+varying vec2 vUv;
+void main() {
+  vUv = aPosition * 0.5 + 0.5;
+  gl_Position = vec4(aPosition, 0.0, 1.0);
+}
+`;
+
+export function compileShader(gl, type, source) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const info = gl.getShaderInfoLog(shader);
+    gl.deleteShader(shader);
+    throw new Error(`Shader compile error: ${info}\n${source}`);
+  }
+  return shader;
+}
+
+export function createProgram(gl, vertexSrc, fragmentSrc, attribLocations = {}) {
+  const program = gl.createProgram();
+  const vs = compileShader(gl, gl.VERTEX_SHADER, vertexSrc);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSrc);
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  Object.entries(attribLocations).forEach(([name, location]) => {
+    gl.bindAttribLocation(program, location, name);
+  });
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const info = gl.getProgramInfoLog(program);
+    gl.deleteProgram(program);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+    throw new Error(`Program link error: ${info}`);
+  }
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+  return program;
+}
+
+export function createFullscreenProgram(gl, fragmentSrc) {
+  return createProgram(gl, FULLSCREEN_VERT, fragmentSrc, { aPosition: 0 });
+}
+
+export function createTexture(gl, width, height, {
+  internalFormat = gl.RGBA16F,
+  format = gl.RGBA,
+  type = gl.FLOAT,
+  minFilter = gl.LINEAR,
+  magFilter = gl.LINEAR,
+  wrapS = gl.CLAMP_TO_EDGE,
+  wrapT = gl.CLAMP_TO_EDGE,
+  data = null,
+} = {}) {
+  const texture = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magFilter);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT);
+  if (data) {
+    gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, width, height, 0, format, type, data);
+  } else {
+    gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, width, height, 0, format, type, null);
+  }
+  gl.bindTexture(gl.TEXTURE_2D, null);
+  return texture;
+}
+
+export function createFramebuffer(gl, texture) {
+  const fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+  const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+  if (status !== gl.FRAMEBUFFER_COMPLETE) {
+    throw new Error(`Framebuffer incomplete: ${status.toString(16)}`);
+  }
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  return fb;
+}
+
+export function createFullscreenQuad(gl) {
+  const quadBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, quadBuffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([
+      -1, -1,
+      1, -1,
+      -1, 1,
+      1, 1,
+    ]),
+    gl.STATIC_DRAW,
+  );
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  return {
+    buffer: quadBuffer,
+    draw() {
+      gl.bindBuffer(gl.ARRAY_BUFFER, quadBuffer);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+      gl.disableVertexAttribArray(0);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    },
+  };
+}
+
+export function resizeCanvasToDisplaySize(canvas) {
+  const width = canvas.clientWidth;
+  const height = canvas.clientHeight;
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width;
+    canvas.height = height;
+    return true;
+  }
+  return false;
+}
+
+export function assertExtensions(gl) {
+  const floatColorBuffer = gl.getExtension('EXT_color_buffer_float');
+  if (!floatColorBuffer) {
+    throw new Error('Required EXT_color_buffer_float extension not available.');
+  }
+  gl.getExtension('OES_texture_float_linear');
+}

--- a/src/core/input.js
+++ b/src/core/input.js
@@ -1,0 +1,89 @@
+const KEY_BINDINGS = {
+  throttle: new Set(['KeyW', 'ArrowUp']),
+  brake: new Set(['KeyS', 'ArrowDown']),
+  left: new Set(['KeyA', 'ArrowLeft']),
+  right: new Set(['KeyD', 'ArrowRight']),
+  reset: new Set(['KeyR']),
+};
+
+export class InputState {
+  constructor() {
+    this.throttle = 0;
+    this.brake = 0;
+    this.steer = 0;
+    this.resetRequested = false;
+    this.dropRequests = [];
+  }
+
+  consumeReset() {
+    const value = this.resetRequested;
+    this.resetRequested = false;
+    return value;
+  }
+
+  consumeDrops() {
+    const drops = this.dropRequests.slice();
+    this.dropRequests.length = 0;
+    return drops;
+  }
+}
+
+export class Input {
+  constructor(targetElement) {
+    this.target = targetElement;
+    this.keysDown = new Set();
+    this.state = new InputState();
+
+    this.onKeyDown = this.onKeyDown.bind(this);
+    this.onKeyUp = this.onKeyUp.bind(this);
+    this.onMouseDown = this.onMouseDown.bind(this);
+
+    window.addEventListener('keydown', this.onKeyDown);
+    window.addEventListener('keyup', this.onKeyUp);
+    this.target.addEventListener('mousedown', this.onMouseDown);
+  }
+
+  dispose() {
+    window.removeEventListener('keydown', this.onKeyDown);
+    window.removeEventListener('keyup', this.onKeyUp);
+    this.target.removeEventListener('mousedown', this.onMouseDown);
+  }
+
+  onKeyDown(event) {
+    this.keysDown.add(event.code);
+    event.preventDefault();
+  }
+
+  onKeyUp(event) {
+    this.keysDown.delete(event.code);
+    event.preventDefault();
+  }
+
+  onMouseDown(event) {
+    const rect = this.target.getBoundingClientRect();
+    const x = (event.clientX - rect.left) / rect.width;
+    const y = (event.clientY - rect.top) / rect.height;
+    this.state.dropRequests.push({ x, y });
+  }
+
+  update() {
+    this.state.throttle = this.hasAny(KEY_BINDINGS.throttle) ? 1 : 0;
+    this.state.brake = this.hasAny(KEY_BINDINGS.brake) ? 1 : 0;
+    const steerLeft = this.hasAny(KEY_BINDINGS.left) ? -1 : 0;
+    const steerRight = this.hasAny(KEY_BINDINGS.right) ? 1 : 0;
+    this.state.steer = steerLeft + steerRight;
+    if (this.hasAny(KEY_BINDINGS.reset)) {
+      this.state.resetRequested = true;
+    }
+    return this.state;
+  }
+
+  hasAny(bindingSet) {
+    for (const key of bindingSet) {
+      if (this.keysDown.has(key)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -1,0 +1,103 @@
+import { resizeCanvasToDisplaySize } from './gl-utils.js';
+import { Input } from './input.js';
+import { WaterSystem } from '../water/water.js';
+import { Renderer } from '../renderer/renderer.js';
+import { Track } from '../game/track.js';
+import { Boat } from '../game/boat.js';
+import { LapManager } from '../game/lap.js';
+import { HUD } from '../ui/hud.js';
+import { WATER_SETTINGS } from './tuning.js';
+
+const FIXED_DT = 1 / 60;
+
+function showCompatibilityNotice(message) {
+  const notice = document.getElementById('compatibility-notice');
+  notice.style.display = 'block';
+  notice.textContent = message;
+}
+
+function hideCompatibilityNotice() {
+  const notice = document.getElementById('compatibility-notice');
+  notice.style.display = 'none';
+}
+
+function mapPointerToWorld({ x, y }) {
+  const worldX = x * 2 - 1;
+  const worldZ = (1 - y) * 2 - 1;
+  return { x: worldX, z: worldZ };
+}
+
+async function init() {
+  const canvas = document.getElementById('gl-canvas');
+  const overlayRoot = document.getElementById('overlay-root');
+
+  const gl = canvas.getContext('webgl2', { antialias: true, alpha: false });
+  if (!gl) {
+    showCompatibilityNotice('WebGL2 is required. Please use a modern browser with WebGL2 support.');
+    return;
+  }
+
+  hideCompatibilityNotice();
+
+  resizeCanvasToDisplaySize(canvas);
+
+  const water = await WaterSystem.create(gl, WATER_SETTINGS);
+  water.updateNormals();
+  const track = new Track(gl);
+  const renderer = await Renderer.create(gl, track);
+  const boat = new Boat(track, water);
+  const lapManager = new LapManager(track);
+  const hud = new HUD(overlayRoot);
+  const input = new Input(canvas);
+
+  renderer.resize(canvas.width, canvas.height);
+
+  let accumulator = 0;
+  let previousTime = performance.now() / 1000;
+
+  function frameLoop(nowMs) {
+    const now = nowMs / 1000;
+    const frameDt = Math.min(now - previousTime, 0.1);
+    previousTime = now;
+    accumulator += frameDt;
+
+    if (resizeCanvasToDisplaySize(canvas)) {
+      renderer.resize(canvas.width, canvas.height);
+    }
+
+    const controls = input.update();
+    if (controls.consumeReset()) {
+      boat.reset();
+      lapManager.reset();
+    }
+
+    const drops = controls.consumeDrops();
+    for (const drop of drops) {
+      const world = mapPointerToWorld(drop);
+      if (Math.abs(world.x) <= 1.05 && Math.abs(world.z) <= 1.05) {
+        water.addDrop(world.x, world.z, 0.04, WATER_SETTINGS.impulseStrength);
+      }
+    }
+
+    while (accumulator >= FIXED_DT) {
+      water.step(FIXED_DT * 0.5);
+      water.step(FIXED_DT * 0.5);
+      water.updateNormals();
+      boat.update(FIXED_DT, controls);
+      lapManager.update(FIXED_DT, boat);
+      accumulator -= FIXED_DT;
+    }
+
+    renderer.render({ water, boat });
+    hud.update(lapManager.getHUDState(boat));
+
+    requestAnimationFrame(frameLoop);
+  }
+
+  requestAnimationFrame(frameLoop);
+}
+
+init().catch((err) => {
+  console.error(err);
+  showCompatibilityNotice('Failed to initialize the renderer. Check console for details.');
+});

--- a/src/core/math.js
+++ b/src/core/math.js
@@ -1,0 +1,278 @@
+export function createMat4() {
+  const out = new Float32Array(16);
+  out[0] = 1;
+  out[5] = 1;
+  out[10] = 1;
+  out[15] = 1;
+  return out;
+}
+
+export function identity(out) {
+  out[0] = 1; out[1] = 0; out[2] = 0; out[3] = 0;
+  out[4] = 0; out[5] = 1; out[6] = 0; out[7] = 0;
+  out[8] = 0; out[9] = 0; out[10] = 1; out[11] = 0;
+  out[12] = 0; out[13] = 0; out[14] = 0; out[15] = 1;
+  return out;
+}
+
+export function perspective(out, fovy, aspect, near, far) {
+  const f = 1.0 / Math.tan(fovy / 2);
+  out[0] = f / aspect;
+  out[1] = 0;
+  out[2] = 0;
+  out[3] = 0;
+
+  out[4] = 0;
+  out[5] = f;
+  out[6] = 0;
+  out[7] = 0;
+
+  out[8] = 0;
+  out[9] = 0;
+  out[10] = (far + near) / (near - far);
+  out[11] = -1;
+
+  out[12] = 0;
+  out[13] = 0;
+  out[14] = (2 * far * near) / (near - far);
+  out[15] = 0;
+  return out;
+}
+
+export function lookAt(out, eye, center, up) {
+  const x0 = eye[0];
+  const x1 = eye[1];
+  const x2 = eye[2];
+  let zx = x0 - center[0];
+  let zy = x1 - center[1];
+  let zz = x2 - center[2];
+  let len = Math.hypot(zx, zy, zz);
+  if (len === 0) {
+    zz = 1;
+  } else {
+    zx /= len;
+    zy /= len;
+    zz /= len;
+  }
+
+  let xx = up[1] * zz - up[2] * zy;
+  let xy = up[2] * zx - up[0] * zz;
+  let xz = up[0] * zy - up[1] * zx;
+  len = Math.hypot(xx, xy, xz);
+  if (len === 0) {
+    xx = 0;
+    xy = 0;
+    xz = 0;
+  } else {
+    xx /= len;
+    xy /= len;
+    xz /= len;
+  }
+
+  const yx = zy * xz - zz * xy;
+  const yy = zz * xx - zx * xz;
+  const yz = zx * xy - zy * xx;
+
+  out[0] = xx;
+  out[1] = yx;
+  out[2] = zx;
+  out[3] = 0;
+
+  out[4] = xy;
+  out[5] = yy;
+  out[6] = zy;
+  out[7] = 0;
+
+  out[8] = xz;
+  out[9] = yz;
+  out[10] = zz;
+  out[11] = 0;
+
+  out[12] = -(xx * x0 + xy * x1 + xz * x2);
+  out[13] = -(yx * x0 + yy * x1 + yz * x2);
+  out[14] = -(zx * x0 + zy * x1 + zz * x2);
+  out[15] = 1;
+  return out;
+}
+
+export function multiply(out, a, b) {
+  const a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
+  const a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7];
+  const a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11];
+  const a30 = a[12], a31 = a[13], a32 = a[14], a33 = a[15];
+
+  const b00 = b[0], b01 = b[1], b02 = b[2], b03 = b[3];
+  const b10 = b[4], b11 = b[5], b12 = b[6], b13 = b[7];
+  const b20 = b[8], b21 = b[9], b22 = b[10], b23 = b[11];
+  const b30 = b[12], b31 = b[13], b32 = b[14], b33 = b[15];
+
+  out[0] = a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30;
+  out[1] = a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31;
+  out[2] = a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32;
+  out[3] = a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33;
+
+  out[4] = a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30;
+  out[5] = a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31;
+  out[6] = a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32;
+  out[7] = a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33;
+
+  out[8] = a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30;
+  out[9] = a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31;
+  out[10] = a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32;
+  out[11] = a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33;
+
+  out[12] = a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30;
+  out[13] = a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31;
+  out[14] = a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32;
+  out[15] = a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33;
+  return out;
+}
+
+export function translate(out, a, v) {
+  const x = v[0];
+  const y = v[1];
+  const z = v[2];
+  if (a === out) {
+    out[12] += a[0] * x + a[4] * y + a[8] * z;
+    out[13] += a[1] * x + a[5] * y + a[9] * z;
+    out[14] += a[2] * x + a[6] * y + a[10] * z;
+    out[15] += a[3] * x + a[7] * y + a[11] * z;
+  } else {
+    const a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
+    const a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7];
+    const a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11];
+    const a30 = a[12], a31 = a[13], a32 = a[14], a33 = a[15];
+
+    out[0] = a00; out[1] = a01; out[2] = a02; out[3] = a03;
+    out[4] = a10; out[5] = a11; out[6] = a12; out[7] = a13;
+    out[8] = a20; out[9] = a21; out[10] = a22; out[11] = a23;
+
+    out[12] = a00 * x + a10 * y + a20 * z + a30;
+    out[13] = a01 * x + a11 * y + a21 * z + a31;
+    out[14] = a02 * x + a12 * y + a22 * z + a32;
+    out[15] = a03 * x + a13 * y + a23 * z + a33;
+  }
+  return out;
+}
+
+export function rotateY(out, a, rad) {
+  const s = Math.sin(rad);
+  const c = Math.cos(rad);
+  const a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
+  const a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11];
+
+  if (a !== out) {
+    out[4] = a[4];
+    out[5] = a[5];
+    out[6] = a[6];
+    out[7] = a[7];
+    out[12] = a[12];
+    out[13] = a[13];
+    out[14] = a[14];
+    out[15] = a[15];
+  }
+
+  out[0] = a00 * c - a20 * s;
+  out[1] = a01 * c - a21 * s;
+  out[2] = a02 * c - a22 * s;
+  out[3] = a03 * c - a23 * s;
+
+  out[8] = a00 * s + a20 * c;
+  out[9] = a01 * s + a21 * c;
+  out[10] = a02 * s + a22 * c;
+  out[11] = a03 * s + a23 * c;
+  return out;
+}
+
+export function scale(out, a, v) {
+  const x = v[0], y = v[1], z = v[2];
+  out[0] = a[0] * x;
+  out[1] = a[1] * x;
+  out[2] = a[2] * x;
+  out[3] = a[3] * x;
+  out[4] = a[4] * y;
+  out[5] = a[5] * y;
+  out[6] = a[6] * y;
+  out[7] = a[7] * y;
+  out[8] = a[8] * z;
+  out[9] = a[9] * z;
+  out[10] = a[10] * z;
+  out[11] = a[11] * z;
+  out[12] = a[12];
+  out[13] = a[13];
+  out[14] = a[14];
+  out[15] = a[15];
+  return out;
+}
+
+export function invert(out, a) {
+  const a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
+  const a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7];
+  const a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11];
+  const a30 = a[12], a31 = a[13], a32 = a[14], a33 = a[15];
+
+  const b00 = a00 * a11 - a01 * a10;
+  const b01 = a00 * a12 - a02 * a10;
+  const b02 = a00 * a13 - a03 * a10;
+  const b03 = a01 * a12 - a02 * a11;
+  const b04 = a01 * a13 - a03 * a11;
+  const b05 = a02 * a13 - a03 * a12;
+  const b06 = a20 * a31 - a21 * a30;
+  const b07 = a20 * a32 - a22 * a30;
+  const b08 = a20 * a33 - a23 * a30;
+  const b09 = a21 * a32 - a22 * a31;
+  const b10 = a21 * a33 - a23 * a31;
+  const b11 = a22 * a33 - a23 * a32;
+
+  let det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
+
+  if (!det) {
+    return null;
+  }
+  det = 1.0 / det;
+
+  out[0] = (a11 * b11 - a12 * b10 + a13 * b09) * det;
+  out[1] = (a02 * b10 - a01 * b11 - a03 * b09) * det;
+  out[2] = (a31 * b05 - a32 * b04 + a33 * b03) * det;
+  out[3] = (a22 * b04 - a21 * b05 - a23 * b03) * det;
+  out[4] = (a12 * b08 - a10 * b11 - a13 * b07) * det;
+  out[5] = (a00 * b11 - a02 * b08 + a03 * b07) * det;
+  out[6] = (a32 * b02 - a30 * b05 - a33 * b01) * det;
+  out[7] = (a20 * b05 - a22 * b02 + a23 * b01) * det;
+  out[8] = (a10 * b10 - a11 * b08 + a13 * b06) * det;
+  out[9] = (a01 * b08 - a00 * b10 - a03 * b06) * det;
+  out[10] = (a30 * b04 - a31 * b02 + a33 * b00) * det;
+  out[11] = (a21 * b02 - a20 * b04 - a23 * b00) * det;
+  out[12] = (a11 * b07 - a10 * b09 - a12 * b06) * det;
+  out[13] = (a00 * b09 - a01 * b07 + a02 * b06) * det;
+  out[14] = (a31 * b01 - a30 * b03 - a32 * b00) * det;
+  out[15] = (a20 * b03 - a21 * b01 + a22 * b00) * det;
+  return out;
+}
+
+export function transpose(out, a) {
+  if (out === a) {
+    let a01 = a[1], a02 = a[2], a03 = a[3];
+    let a12 = a[6], a13 = a[7];
+    let a23 = a[11];
+
+    out[1] = a[4];
+    out[2] = a[8];
+    out[3] = a[12];
+    out[4] = a01;
+    out[6] = a[9];
+    out[7] = a[13];
+    out[8] = a02;
+    out[9] = a12;
+    out[11] = a[14];
+    out[12] = a03;
+    out[13] = a13;
+    out[14] = a23;
+  } else {
+    out[0] = a[0]; out[1] = a[4]; out[2] = a[8]; out[3] = a[12];
+    out[4] = a[1]; out[5] = a[5]; out[6] = a[9]; out[7] = a[13];
+    out[8] = a[2]; out[9] = a[6]; out[10] = a[10]; out[11] = a[14];
+    out[12] = a[3]; out[13] = a[7]; out[14] = a[11]; out[15] = a[15];
+  }
+  return out;
+}

--- a/src/core/tuning.js
+++ b/src/core/tuning.js
@@ -1,0 +1,41 @@
+export const WATER_SETTINGS = {
+  size: 256,
+  damping: 0.015,
+  waveSpeed: 0.9,
+  impulseStrength: 0.04,
+};
+
+export const BOAT_SETTINGS = {
+  mass: 1.0,
+  draft: 0.035,
+  buoyK: 60,
+  buoyDamp: 8,
+  linDrag: 1.2,
+  latDrag: 6.0,
+  thrust: 2.2,
+  rudderPower: 2.4,
+  turnDrag: 1.8,
+  wakeStrength: 0.02,
+  wakeRadius: 0.02,
+};
+
+export const TRACK_SETTINGS = {
+  width: 0.12,
+  maskResolution: 512,
+};
+
+export const CAMERA_SETTINGS = {
+  eye: [0.0, 1.5, 1.6],
+  target: [0.0, 0.0, 0.0],
+  up: [0, 1, 0],
+  fov: 45 * (Math.PI / 180),
+  near: 0.1,
+  far: 10,
+};
+
+export const ENVIRONMENT_SETTINGS = {
+  sunDirection: [0.3, 0.8, 0.4],
+  skyColor: [0.10, 0.18, 0.28],
+  waterDeepColor: [0.02, 0.07, 0.12],
+  waterShallowColor: [0.08, 0.18, 0.26],
+};

--- a/src/game/boat.js
+++ b/src/game/boat.js
@@ -1,0 +1,154 @@
+import { BOAT_SETTINGS } from '../core/tuning.js';
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export class Boat {
+  constructor(track, water) {
+    this.track = track;
+    this.water = water;
+    this.settings = { ...BOAT_SETTINGS };
+    this.position = [0, 0, 0];
+    this.velocity = [0, 0, 0];
+    this.heading = 0;
+    this.angVel = 0;
+    this.speed = 0;
+    this.onTrack = true;
+    this.wakeTimer = 0;
+    this.lastProbe = {
+      height: 0,
+      normalX: 0,
+      normalZ: 0,
+    };
+    this.reset();
+  }
+
+  reset() {
+    const points = this.track.getPoints();
+    const start = points[0];
+    const next = points[1];
+    const tangent = [next.x - start.x, next.z - start.z];
+    const length = Math.hypot(tangent[0], tangent[1]) || 1;
+    const forward = [tangent[0] / length, tangent[1] / length];
+    this.heading = Math.atan2(forward[0], forward[1]);
+    this.position[0] = start.x - forward[0] * 0.15;
+    this.position[2] = start.z - forward[1] * 0.15;
+    this.position[1] = this.water.sampleProbe(this.position[0], this.position[2]).height + this.settings.draft * 0.5;
+    this.velocity[0] = 0;
+    this.velocity[1] = 0;
+    this.velocity[2] = 0;
+    this.angVel = 0;
+    this.wakeTimer = 0;
+  }
+
+  getForwardVector() {
+    return [Math.sin(this.heading), 0, Math.cos(this.heading)];
+  }
+
+  getRightVector() {
+    return [Math.cos(this.heading), 0, -Math.sin(this.heading)];
+  }
+
+  update(dt, input) {
+    const {
+      mass,
+      draft,
+      buoyK,
+      buoyDamp,
+      linDrag,
+      latDrag,
+      thrust,
+      rudderPower,
+      turnDrag,
+      wakeStrength,
+      wakeRadius,
+    } = this.settings;
+
+    const probe = this.water.sampleProbe(this.position[0], this.position[2]);
+    this.lastProbe = probe;
+    const waterHeight = probe.height;
+    const normalX = probe.normalX;
+    const normalZ = probe.normalZ;
+
+    const forward = this.getForwardVector();
+    const right = this.getRightVector();
+
+    const throttleInput = input.throttle - input.brake;
+    const steerInput = clamp(input.steer, -1, 1);
+
+    const forces = [0, -9.81 * mass, 0];
+
+    const submersion = waterHeight - this.position[1] + draft;
+    if (submersion > 0) {
+      forces[1] += buoyK * submersion - buoyDamp * this.velocity[1];
+      forces[0] += normalX * submersion * 4.5;
+      forces[2] += normalZ * submersion * 4.5;
+    }
+
+    const throttleForce = thrust * throttleInput;
+    if (submersion > -draft * 0.5) {
+      forces[0] += forward[0] * throttleForce;
+      forces[2] += forward[2] * throttleForce;
+    }
+
+    forces[0] -= this.velocity[0] * linDrag;
+    forces[1] -= this.velocity[1] * (linDrag * 0.6);
+    forces[2] -= this.velocity[2] * linDrag;
+
+    const lateralSpeed = this.velocity[0] * right[0] + this.velocity[2] * right[2];
+    forces[0] -= right[0] * lateralSpeed * latDrag;
+    forces[2] -= right[2] * lateralSpeed * latDrag;
+
+    const accelX = forces[0] / mass;
+    const accelY = forces[1] / mass;
+    const accelZ = forces[2] / mass;
+
+    this.velocity[0] += accelX * dt;
+    this.velocity[1] += accelY * dt;
+    this.velocity[2] += accelZ * dt;
+
+    this.position[0] += this.velocity[0] * dt;
+    this.position[1] += this.velocity[1] * dt;
+    this.position[2] += this.velocity[2] * dt;
+
+    this.speed = Math.hypot(this.velocity[0], this.velocity[2]);
+
+    const torque = rudderPower * steerInput * clamp(this.speed, 0, 6);
+    this.angVel += (torque - this.angVel * turnDrag) * dt;
+    this.heading += this.angVel * dt;
+
+    this.applyBounds();
+
+    const mask = this.track.sampleMask(this.position[0], this.position[2]);
+    this.onTrack = mask > 0.35;
+    if (!this.onTrack) {
+      this.velocity[0] *= 0.985;
+      this.velocity[2] *= 0.985;
+    }
+
+    this.wakeTimer += dt * Math.max(0.2, this.speed);
+    if (submersion > 0.01 && this.wakeTimer > 0.08 && (Math.abs(throttleInput) > 0.2 || Math.abs(steerInput) > 0.2)) {
+      this.water.addDrop(this.position[0], this.position[2], wakeRadius, wakeStrength);
+      this.wakeTimer = 0;
+    }
+  }
+
+  applyBounds() {
+    const bound = 0.95;
+    for (let i = 0; i < 3; i += 2) {
+      const idx = i;
+      if (this.position[idx] > bound) {
+        this.position[idx] = bound;
+        this.velocity[idx] *= -0.3;
+      } else if (this.position[idx] < -bound) {
+        this.position[idx] = -bound;
+        this.velocity[idx] *= -0.3;
+      }
+    }
+    if (this.position[1] < -0.4) {
+      this.position[1] = -0.4;
+      this.velocity[1] = 0;
+    }
+  }
+}

--- a/src/game/lap.js
+++ b/src/game/lap.js
@@ -1,0 +1,107 @@
+export class LapManager {
+  constructor(track) {
+    this.track = track;
+    this.checkpoints = track.getCheckpoints();
+    this.reset();
+    this.bestLap = null;
+    this.lastLapTime = null;
+    this.lastLapDelta = null;
+  }
+
+  reset() {
+    this.currentLapTime = 0;
+    this.active = false;
+    this.awaitingStart = true;
+    this.checkpointHits = 0;
+    this.wasInStartArea = true;
+  }
+
+  update(dt, boat) {
+    const start = this.track.getStartLine().point;
+    const radius = this.track.startAreaRadius;
+    const dx = boat.position[0] - start.x;
+    const dz = boat.position[2] - start.z;
+    const distToStart = Math.hypot(dx, dz);
+    const inStartArea = distToStart <= radius;
+
+    if (!this.active && this.awaitingStart && !inStartArea && this.wasInStartArea && boat.onTrack) {
+      this.startLap();
+    }
+
+    if (this.active) {
+      this.currentLapTime += dt;
+      this.checkCheckpoint(boat);
+      const totalCheckpoints = this.checkpoints.length;
+      if (
+        inStartArea &&
+        !this.wasInStartArea &&
+        this.currentLapTime > 1.0 &&
+        this.checkpointHits >= totalCheckpoints
+      ) {
+        this.finishLap();
+      }
+    }
+
+    this.wasInStartArea = inStartArea;
+  }
+
+  startLap() {
+    this.active = true;
+    this.awaitingStart = false;
+    this.currentLapTime = 0;
+    this.checkpointHits = 0;
+    this.lastLapDelta = null;
+  }
+
+  finishLap() {
+    this.active = false;
+    this.awaitingStart = true;
+    this.lastLapTime = this.currentLapTime;
+    if (this.bestLap == null || this.currentLapTime < this.bestLap) {
+      if (this.bestLap != null) {
+        this.lastLapDelta = this.currentLapTime - this.bestLap;
+      } else {
+        this.lastLapDelta = 0;
+      }
+      this.bestLap = this.currentLapTime;
+    } else {
+      this.lastLapDelta = this.currentLapTime - this.bestLap;
+    }
+    this.currentLapTime = 0;
+    this.checkpointHits = 0;
+  }
+
+  checkCheckpoint(boat) {
+    const checkpoint = this.checkpoints[this.checkpointHits];
+    if (!checkpoint) {
+      return;
+    }
+    const dx = boat.position[0] - checkpoint.position.x;
+    const dz = boat.position[2] - checkpoint.position.z;
+    const dist = Math.hypot(dx, dz);
+    if (dist <= checkpoint.radius) {
+      this.checkpointHits += 1;
+    }
+  }
+
+  getHUDState(boat) {
+    const totalCheckpoints = this.checkpoints.length;
+    const lapTime = this.active ? this.currentLapTime : (this.lastLapTime ?? 0);
+    const lapDelta = this.active && this.bestLap != null ? this.currentLapTime - this.bestLap : this.lastLapDelta;
+    const message = this.active
+      ? 'Lap in progress'
+      : this.bestLap
+        ? 'Leave the gate to start next lap'
+        : 'Throttle across the gate to start';
+
+    return {
+      lapTime,
+      bestLap: this.bestLap,
+      lapDelta,
+      speed: boat.speed,
+      checkpointIndex: Math.min(this.checkpointHits, totalCheckpoints),
+      totalCheckpoints,
+      message,
+    };
+  }
+}

--- a/src/game/track.js
+++ b/src/game/track.js
@@ -1,0 +1,184 @@
+import { TRACK_SETTINGS } from '../core/tuning.js';
+
+function segmentDistance(px, pz, ax, az, bx, bz) {
+  const abx = bx - ax;
+  const abz = bz - az;
+  const apx = px - ax;
+  const apz = pz - az;
+  const abLenSq = abx * abx + abz * abz;
+  let t = 0;
+  if (abLenSq > 0) {
+    t = (apx * abx + apz * abz) / abLenSq;
+  }
+  t = Math.max(0, Math.min(1, t));
+  const cx = ax + abx * t;
+  const cz = az + abz * t;
+  const dx = px - cx;
+  const dz = pz - cz;
+  return Math.hypot(dx, dz);
+}
+
+function polylineDistance(points, x, z) {
+  let minDist = Infinity;
+  for (let i = 0; i < points.length; i += 1) {
+    const a = points[i];
+    const b = points[(i + 1) % points.length];
+    const dist = segmentDistance(x, z, a.x, a.z, b.x, b.z);
+    if (dist < minDist) {
+      minDist = dist;
+    }
+  }
+  return minDist;
+}
+
+function normalize2(vx, vz) {
+  const len = Math.hypot(vx, vz);
+  if (len === 0) {
+    return [0, 0];
+  }
+  return [vx / len, vz / len];
+}
+
+export class Track {
+  constructor(gl, settings = TRACK_SETTINGS) {
+    this.settings = settings;
+    this.points = this.createOvalCourse();
+    this.maskSize = settings.maskResolution;
+    this.maskData = new Uint8Array(this.maskSize * this.maskSize);
+    this.maskTexture = this.createMaskTexture(gl);
+    this.checkpoints = this.createCheckpoints();
+    this.startAreaRadius = settings.width * 1.4;
+
+    const start = this.points[0];
+    const next = this.points[1];
+    const tangent = [next.x - start.x, next.z - start.z];
+    const normal = normalize2(tangent[1], -tangent[0]);
+    this.startLine = {
+      point: { x: start.x, z: start.z },
+      normal: { x: normal[0], z: normal[1] },
+    };
+  }
+
+  createOvalCourse() {
+    const points = [];
+    const radiusX = 0.72;
+    const radiusZ = 0.42;
+    const segments = 48;
+    for (let i = 0; i < segments; i += 1) {
+      const t = (i / segments) * Math.PI * 2;
+      const wobble = 0.05 * Math.sin(t * 3.0);
+      const x = Math.cos(t) * (radiusX + wobble);
+      const z = Math.sin(t) * (radiusZ + wobble * 0.6);
+      points.push({ x, z });
+    }
+    return points;
+  }
+
+  createMaskTexture(gl) {
+    const size = this.maskSize;
+    const width = this.settings.width;
+    const falloff = width * 0.5;
+    const data = this.maskData;
+    for (let y = 0; y < size; y += 1) {
+      const v = y / (size - 1);
+      const z = v * 2 - 1;
+      for (let x = 0; x < size; x += 1) {
+        const u = x / (size - 1);
+        const wx = u * 2 - 1;
+        const dist = polylineDistance(this.points, wx, z);
+        let value = 0;
+        if (dist <= width) {
+          value = 1;
+        } else if (dist <= width + falloff) {
+          const t = 1 - (dist - width) / falloff;
+          value = t * t;
+        }
+        data[y * size + x] = Math.max(0, Math.min(255, Math.floor(value * 255)));
+      }
+    }
+    const texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.R8,
+      size,
+      size,
+      0,
+      gl.RED,
+      gl.UNSIGNED_BYTE,
+      data,
+    );
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    return texture;
+  }
+
+  createCheckpoints() {
+    const checkpoints = [];
+    const total = this.points.length;
+    const step = Math.floor(total / 4);
+    for (let i = step; i < total; i += step) {
+      const point = this.points[i % total];
+      checkpoints.push({
+        index: checkpoints.length + 1,
+        position: { x: point.x, z: point.z },
+        radius: this.settings.width * 1.1,
+      });
+    }
+    return checkpoints;
+  }
+
+  getMaskTexture() {
+    return this.maskTexture;
+  }
+
+  getPoints() {
+    return this.points;
+  }
+
+  getCheckpoints() {
+    return this.checkpoints;
+  }
+
+  getStartLine() {
+    return this.startLine;
+  }
+
+  sampleMask(x, z) {
+    const size = this.maskSize;
+    const u = (x * 0.5 + 0.5) * (size - 1);
+    const v = (z * 0.5 + 0.5) * (size - 1);
+    const ix = Math.max(0, Math.min(size - 1, Math.floor(u)));
+    const iy = Math.max(0, Math.min(size - 1, Math.floor(v)));
+    const fx = Math.min(1, Math.max(0, u - ix));
+    const fy = Math.min(1, Math.max(0, v - iy));
+
+    const idx = iy * size + ix;
+    const ix1 = Math.min(size - 1, ix + 1);
+    const iy1 = Math.min(size - 1, iy + 1);
+    const idxRight = iy * size + ix1;
+    const idxDown = iy1 * size + ix;
+    const idxDownRight = iy1 * size + ix1;
+
+    const top = this.maskData[idx] * (1 - fx) + this.maskData[idxRight] * fx;
+    const bottom = this.maskData[idxDown] * (1 - fx) + this.maskData[idxDownRight] * fx;
+    const value = top * (1 - fy) + bottom * fy;
+    return value / 255;
+  }
+
+  distanceToTrack(x, z) {
+    return polylineDistance(this.points, x, z);
+  }
+
+  signedDistanceToStartLine(x, z) {
+    const { point, normal } = this.startLine;
+    const dx = x - point.x;
+    const dz = z - point.z;
+    return dx * normal.x + dz * normal.z;
+  }
+}

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -1,0 +1,302 @@
+import { createProgram } from '../core/gl-utils.js';
+import {
+  createMat4,
+  identity,
+  lookAt,
+  perspective,
+  multiply,
+  rotateY,
+  translate,
+  invert,
+  transpose,
+} from '../core/math.js';
+import {
+  CAMERA_SETTINGS,
+  ENVIRONMENT_SETTINGS,
+} from '../core/tuning.js';
+
+async function loadText(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load shader: ${url}`);
+  }
+  return response.text();
+}
+
+function normalizeVec3(v) {
+  const len = Math.hypot(v[0], v[1], v[2]);
+  if (len === 0) {
+    return [0, 0, 0];
+  }
+  return [v[0] / len, v[1] / len, v[2] / len];
+}
+
+function buildBoatMesh() {
+  const halfLength = 0.22;
+  const halfWidth = 0.06;
+  const hullHeight = 0.06;
+
+  const verts = [
+    [-halfWidth, 0, -halfLength],
+    [halfWidth, 0, -halfLength],
+    [0, 0, halfLength],
+    [-halfWidth, hullHeight, -halfLength * 0.6],
+    [halfWidth, hullHeight, -halfLength * 0.6],
+    [0, hullHeight, halfLength],
+  ];
+
+  const faces = [
+    [0, 1, 2],
+    [3, 5, 4],
+    [0, 2, 3],
+    [3, 2, 5],
+    [1, 4, 2],
+    [4, 5, 2],
+    [0, 3, 1],
+    [1, 3, 4],
+  ];
+
+  const positions = [];
+  const normals = [];
+
+  for (const face of faces) {
+    const a = verts[face[0]];
+    const b = verts[face[1]];
+    const c = verts[face[2]];
+    const ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    const ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+    const nx = ab[1] * ac[2] - ab[2] * ac[1];
+    const ny = ab[2] * ac[0] - ab[0] * ac[2];
+    const nz = ab[0] * ac[1] - ab[1] * ac[0];
+    const len = Math.hypot(nx, ny, nz) || 1;
+    const normal = [nx / len, ny / len, nz / len];
+
+    for (const index of face) {
+      const v = verts[index];
+      positions.push(v[0], v[1], v[2]);
+      normals.push(normal[0], normal[1], normal[2]);
+    }
+  }
+
+  return {
+    positions: new Float32Array(positions),
+    normals: new Float32Array(normals),
+    count: positions.length / 3,
+  };
+}
+
+export class Renderer {
+  static async create(gl, track) {
+    const [waterVert, waterFrag, boatVert, boatFrag] = await Promise.all([
+      loadText('shaders/water_surface.vert'),
+      loadText('shaders/water_surface.frag'),
+      loadText('shaders/boat.vert'),
+      loadText('shaders/boat.frag'),
+    ]);
+    return new Renderer(gl, track, {
+      waterVert,
+      waterFrag,
+      boatVert,
+      boatFrag,
+    });
+  }
+
+  constructor(gl, track, shaderSources) {
+    this.gl = gl;
+    this.track = track;
+    this.canvasWidth = gl.canvas.width;
+    this.canvasHeight = gl.canvas.height;
+
+    this.waterProgram = createProgram(gl, shaderSources.waterVert, shaderSources.waterFrag, {
+      aPosition: 0,
+      aUV: 1,
+    });
+    this.waterUniforms = {
+      viewProjection: gl.getUniformLocation(this.waterProgram, 'uViewProjection'),
+      height: gl.getUniformLocation(this.waterProgram, 'uHeight'),
+      normal: gl.getUniformLocation(this.waterProgram, 'uNormal'),
+      trackMask: gl.getUniformLocation(this.waterProgram, 'uTrackMask'),
+      cameraPos: gl.getUniformLocation(this.waterProgram, 'uCameraPos'),
+      sunDir: gl.getUniformLocation(this.waterProgram, 'uSunDir'),
+      skyColor: gl.getUniformLocation(this.waterProgram, 'uSkyColor'),
+      waterDeepColor: gl.getUniformLocation(this.waterProgram, 'uWaterDeepColor'),
+      waterShallowColor: gl.getUniformLocation(this.waterProgram, 'uWaterShallowColor'),
+    };
+
+    this.waterBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.waterBuffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([
+        -1, -1, 0, 0,
+        1, -1, 1, 0,
+        -1, 1, 0, 1,
+        1, 1, 1, 1,
+      ]),
+      gl.STATIC_DRAW,
+    );
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    const boatMesh = buildBoatMesh();
+    this.boatProgram = createProgram(gl, shaderSources.boatVert, shaderSources.boatFrag, {
+      aPosition: 0,
+      aNormal: 1,
+    });
+    this.boatUniforms = {
+      model: gl.getUniformLocation(this.boatProgram, 'uModel'),
+      viewProjection: gl.getUniformLocation(this.boatProgram, 'uViewProjection'),
+      normalMatrix: gl.getUniformLocation(this.boatProgram, 'uNormalMatrix'),
+      cameraPos: gl.getUniformLocation(this.boatProgram, 'uCameraPos'),
+      lightDir: gl.getUniformLocation(this.boatProgram, 'uLightDir'),
+      baseColor: gl.getUniformLocation(this.boatProgram, 'uBaseColor'),
+    };
+
+    this.boatPositionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.boatPositionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, boatMesh.positions, gl.STATIC_DRAW);
+    this.boatNormalBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.boatNormalBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, boatMesh.normals, gl.STATIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    this.boatVertexCount = boatMesh.count;
+    this.boatColor = new Float32Array([0.9, 0.2, 0.3]);
+
+    this.trackMask = track.getMaskTexture();
+
+    this.viewMatrix = createMat4();
+    this.projectionMatrix = createMat4();
+    this.viewProjectionMatrix = createMat4();
+    this.tmpMatA = createMat4();
+    this.tmpMatB = createMat4();
+
+    this.normalMatrix3 = new Float32Array(9);
+
+    this.sunDirection = normalizeVec3(ENVIRONMENT_SETTINGS.sunDirection);
+    this.skyColor = ENVIRONMENT_SETTINGS.skyColor;
+    this.deepColor = ENVIRONMENT_SETTINGS.waterDeepColor;
+    this.shallowColor = ENVIRONMENT_SETTINGS.waterShallowColor;
+
+    gl.enable(gl.DEPTH_TEST);
+    gl.enable(gl.CULL_FACE);
+  }
+
+  resize(width, height) {
+    this.canvasWidth = width;
+    this.canvasHeight = height;
+    const aspect = width / height;
+    perspective(this.projectionMatrix, CAMERA_SETTINGS.fov, aspect, CAMERA_SETTINGS.near, CAMERA_SETTINGS.far);
+  }
+
+  computeCamera(boat) {
+    const forward = boat.getForwardVector();
+    const eye = [
+      boat.position[0] + forward[0] * 0.2 + CAMERA_SETTINGS.eye[0],
+      CAMERA_SETTINGS.eye[1],
+      boat.position[2] + forward[2] * 0.2 + CAMERA_SETTINGS.eye[2],
+    ];
+    const target = [
+      boat.position[0] + forward[0] * 0.6,
+      boat.position[1] * 0.2,
+      boat.position[2] + forward[2] * 0.6,
+    ];
+    lookAt(this.viewMatrix, eye, target, CAMERA_SETTINGS.up);
+    multiply(this.viewProjectionMatrix, this.projectionMatrix, this.viewMatrix);
+    return { eye, target };
+  }
+
+  render(scene) {
+    const { gl } = this;
+    const { water, boat } = scene;
+    const canvas = gl.canvas;
+    if (canvas.width !== this.canvasWidth || canvas.height !== this.canvasHeight) {
+      this.resize(canvas.width, canvas.height);
+    }
+
+    gl.viewport(0, 0, canvas.width, canvas.height);
+    gl.clearColor(0.04, 0.07, 0.1, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    const camera = this.computeCamera(boat);
+
+    this.renderWater(water, camera);
+    this.renderBoat(boat, camera);
+  }
+
+  renderWater(water, camera) {
+    const { gl } = this;
+    gl.useProgram(this.waterProgram);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.waterBuffer);
+    const stride = 4 * 4;
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, stride, 0);
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 2, gl.FLOAT, false, stride, 8);
+
+    gl.uniformMatrix4fv(this.waterUniforms.viewProjection, false, this.viewProjectionMatrix);
+    gl.uniform3fv(this.waterUniforms.cameraPos, camera.eye);
+    gl.uniform3fv(this.waterUniforms.sunDir, this.sunDirection);
+    gl.uniform3fv(this.waterUniforms.skyColor, this.skyColor);
+    gl.uniform3fv(this.waterUniforms.waterDeepColor, this.deepColor);
+    gl.uniform3fv(this.waterUniforms.waterShallowColor, this.shallowColor);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, water.heightTexture);
+    gl.uniform1i(this.waterUniforms.height, 0);
+
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, water.normalTextureHandle);
+    gl.uniform1i(this.waterUniforms.normal, 1);
+
+    gl.activeTexture(gl.TEXTURE2);
+    gl.bindTexture(gl.TEXTURE_2D, this.trackMask);
+    gl.uniform1i(this.waterUniforms.trackMask, 2);
+
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+    gl.disableVertexAttribArray(0);
+    gl.disableVertexAttribArray(1);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  }
+
+  renderBoat(boat, camera) {
+    const { gl } = this;
+    gl.useProgram(this.boatProgram);
+
+    const model = identity(this.tmpMatA);
+    rotateY(model, model, boat.heading);
+    translate(model, model, boat.position);
+
+    const inverse = invert(this.tmpMatB, model);
+    const normalMatrix4 = transpose(this.tmpMatB, inverse);
+    this.normalMatrix3[0] = normalMatrix4[0];
+    this.normalMatrix3[1] = normalMatrix4[1];
+    this.normalMatrix3[2] = normalMatrix4[2];
+    this.normalMatrix3[3] = normalMatrix4[4];
+    this.normalMatrix3[4] = normalMatrix4[5];
+    this.normalMatrix3[5] = normalMatrix4[6];
+    this.normalMatrix3[6] = normalMatrix4[8];
+    this.normalMatrix3[7] = normalMatrix4[9];
+    this.normalMatrix3[8] = normalMatrix4[10];
+
+    gl.uniformMatrix4fv(this.boatUniforms.model, false, model);
+    gl.uniformMatrix4fv(this.boatUniforms.viewProjection, false, this.viewProjectionMatrix);
+    gl.uniformMatrix3fv(this.boatUniforms.normalMatrix, false, this.normalMatrix3);
+    gl.uniform3fv(this.boatUniforms.cameraPos, camera.eye);
+    gl.uniform3fv(this.boatUniforms.lightDir, this.sunDirection);
+    gl.uniform3fv(this.boatUniforms.baseColor, this.boatColor);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.boatPositionBuffer);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.boatNormalBuffer);
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 3, gl.FLOAT, false, 0, 0);
+
+    gl.drawArrays(gl.TRIANGLES, 0, this.boatVertexCount);
+
+    gl.disableVertexAttribArray(0);
+    gl.disableVertexAttribArray(1);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  }
+}

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -1,0 +1,84 @@
+function formatTime(seconds) {
+  if (Number.isNaN(seconds)) {
+    return '--:--.---';
+  }
+  const totalMs = Math.max(0, Math.floor(seconds * 1000));
+  const minutes = Math.floor(totalMs / 60000);
+  const secondsPart = Math.floor((totalMs % 60000) / 1000);
+  const msPart = totalMs % 1000;
+  return `${minutes.toString().padStart(2, '0')}:${secondsPart
+    .toString()
+    .padStart(2, '0')}.${msPart.toString().padStart(3, '0')}`;
+}
+
+export class HUD {
+  constructor(root) {
+    this.root = root;
+    this.container = document.createElement('div');
+    this.container.style.position = 'absolute';
+    this.container.style.top = '1.5rem';
+    this.container.style.left = '50%';
+    this.container.style.transform = 'translateX(-50%)';
+    this.container.style.textAlign = 'center';
+    this.container.style.fontSize = '1.1rem';
+    this.container.style.textShadow = '0 1px 4px rgba(0,0,0,0.8)';
+
+    this.timerEl = document.createElement('div');
+    this.timerEl.style.fontSize = '2rem';
+    this.timerEl.style.fontWeight = '600';
+
+    this.deltaEl = document.createElement('div');
+    this.deltaEl.style.marginTop = '0.2rem';
+    this.deltaEl.style.opacity = '0.85';
+
+    this.statusEl = document.createElement('div');
+    this.statusEl.style.marginTop = '0.6rem';
+    this.statusEl.style.fontSize = '0.9rem';
+    this.statusEl.style.opacity = '0.75';
+
+    this.container.appendChild(this.timerEl);
+    this.container.appendChild(this.deltaEl);
+    this.container.appendChild(this.statusEl);
+    this.root.appendChild(this.container);
+
+    this.sideContainer = document.createElement('div');
+    this.sideContainer.style.position = 'absolute';
+    this.sideContainer.style.bottom = '1.5rem';
+    this.sideContainer.style.left = '1.5rem';
+    this.sideContainer.style.fontSize = '1rem';
+    this.sideContainer.style.textShadow = '0 1px 4px rgba(0,0,0,0.8)';
+
+    this.speedEl = document.createElement('div');
+    this.checkpointEl = document.createElement('div');
+
+    this.sideContainer.appendChild(this.speedEl);
+    this.sideContainer.appendChild(this.checkpointEl);
+    this.root.appendChild(this.sideContainer);
+  }
+
+  update({
+    lapTime,
+    bestLap,
+    lapDelta,
+    speed,
+    checkpointIndex,
+    totalCheckpoints,
+    message,
+  }) {
+    this.timerEl.textContent = formatTime(lapTime ?? 0);
+    if (Number.isFinite(lapDelta)) {
+      const sign = lapDelta >= 0 ? '+' : '−';
+      this.deltaEl.textContent = `${sign}${formatTime(Math.abs(lapDelta))}`;
+      this.deltaEl.style.color = lapDelta <= 0 ? '#8bf5b5' : '#f5938b';
+    } else if (Number.isFinite(bestLap)) {
+      this.deltaEl.textContent = `PB ${formatTime(bestLap)}`;
+      this.deltaEl.style.color = '#9fc9ff';
+    } else {
+      this.deltaEl.textContent = 'Set a lap!';
+      this.deltaEl.style.color = '#9fc9ff';
+    }
+    this.speedEl.textContent = `Speed: ${(speed ?? 0).toFixed(2)} u/s`;
+    this.checkpointEl.textContent = `Checkpoint: ${checkpointIndex}/${totalCheckpoints}`;
+    this.statusEl.textContent = message ?? '';
+  }
+}

--- a/src/water/water.js
+++ b/src/water/water.js
@@ -1,0 +1,210 @@
+import { WATER_SETTINGS } from '../core/tuning.js';
+import {
+  createTexture,
+  createFramebuffer,
+  createFullscreenProgram,
+  createFullscreenQuad,
+  assertExtensions,
+} from '../core/gl-utils.js';
+
+async function loadText(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load shader: ${url}`);
+  }
+  return response.text();
+}
+
+export class WaterSystem {
+  static async create(gl, settings = WATER_SETTINGS) {
+    assertExtensions(gl);
+    const [dropSrc, updateSrc, normalSrc, probeSrc] = await Promise.all([
+      loadText('shaders/water_drop.frag'),
+      loadText('shaders/water_update.frag'),
+      loadText('shaders/water_normal.frag'),
+      loadText('shaders/probe.frag'),
+    ]);
+    return new WaterSystem(gl, settings, {
+      dropSrc,
+      updateSrc,
+      normalSrc,
+      probeSrc,
+    });
+  }
+
+  constructor(gl, settings, shaderSources) {
+    this.gl = gl;
+    this.settings = settings;
+    this.size = settings.size;
+    this.texel = [1 / this.size, 1 / this.size];
+
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
+    gl.pixelStorei(gl.PACK_ALIGNMENT, 1);
+
+    this.quad = createFullscreenQuad(gl);
+
+    this.heightTextures = [
+      createTexture(gl, this.size, this.size),
+      createTexture(gl, this.size, this.size),
+    ];
+    this.framebuffers = [
+      createFramebuffer(gl, this.heightTextures[0]),
+      createFramebuffer(gl, this.heightTextures[1]),
+    ];
+    this.currentIndex = 0;
+
+    this.normalTexture = createTexture(gl, this.size, this.size);
+    this.normalFramebuffer = createFramebuffer(gl, this.normalTexture);
+
+    this.probeTexture = createTexture(gl, 1, 1);
+    this.probeFramebuffer = createFramebuffer(gl, this.probeTexture);
+    this.probeReadBuffer = new Float32Array(4);
+
+    this.dropProgram = createFullscreenProgram(gl, shaderSources.dropSrc);
+    this.dropUniforms = {
+      prev: gl.getUniformLocation(this.dropProgram, 'uPrev'),
+      center: gl.getUniformLocation(this.dropProgram, 'uCenter'),
+      radius: gl.getUniformLocation(this.dropProgram, 'uRadius'),
+      strength: gl.getUniformLocation(this.dropProgram, 'uStrength'),
+    };
+
+    this.updateProgram = createFullscreenProgram(gl, shaderSources.updateSrc);
+    this.updateUniforms = {
+      prev: gl.getUniformLocation(this.updateProgram, 'uPrev'),
+      texel: gl.getUniformLocation(this.updateProgram, 'uTexel'),
+      waveSpeed: gl.getUniformLocation(this.updateProgram, 'uWaveSpeed'),
+      damping: gl.getUniformLocation(this.updateProgram, 'uDamping'),
+      dt: gl.getUniformLocation(this.updateProgram, 'uDt'),
+    };
+
+    this.normalProgram = createFullscreenProgram(gl, shaderSources.normalSrc);
+    this.normalUniforms = {
+      height: gl.getUniformLocation(this.normalProgram, 'uHeight'),
+      texel: gl.getUniformLocation(this.normalProgram, 'uTexel'),
+    };
+
+    this.probeProgram = createFullscreenProgram(gl, shaderSources.probeSrc);
+    this.probeUniforms = {
+      height: gl.getUniformLocation(this.probeProgram, 'uHeight'),
+      normal: gl.getUniformLocation(this.probeProgram, 'uNormal'),
+      center: gl.getUniformLocation(this.probeProgram, 'uProbeCenter'),
+    };
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  }
+
+  get heightTexture() {
+    return this.heightTextures[this.currentIndex];
+  }
+
+  get velocityTexture() {
+    return this.heightTextures[this.currentIndex];
+  }
+
+  get normalTextureHandle() {
+    return this.normalTexture;
+  }
+
+  addDrop(x, z, radius, strength) {
+    const gl = this.gl;
+    const uv = [(x * 0.5) + 0.5, (z * 0.5) + 0.5];
+    const radiusUv = radius * 0.5;
+
+    const sourceIndex = this.currentIndex;
+    const targetIndex = (this.currentIndex + 1) % 2;
+
+    gl.useProgram(this.dropProgram);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffers[targetIndex]);
+    gl.viewport(0, 0, this.size, this.size);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.heightTextures[sourceIndex]);
+    gl.uniform1i(this.dropUniforms.prev, 0);
+    gl.uniform2f(this.dropUniforms.center, uv[0], uv[1]);
+    gl.uniform1f(this.dropUniforms.radius, radiusUv);
+    gl.uniform1f(this.dropUniforms.strength, strength);
+
+    this.quad.draw();
+
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    this.currentIndex = targetIndex;
+  }
+
+  step(dt) {
+    const gl = this.gl;
+    const sourceIndex = this.currentIndex;
+    const targetIndex = (this.currentIndex + 1) % 2;
+
+    gl.useProgram(this.updateProgram);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffers[targetIndex]);
+    gl.viewport(0, 0, this.size, this.size);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.heightTextures[sourceIndex]);
+    gl.uniform1i(this.updateUniforms.prev, 0);
+    gl.uniform2f(this.updateUniforms.texel, this.texel[0], this.texel[1]);
+    gl.uniform1f(this.updateUniforms.waveSpeed, this.settings.waveSpeed);
+    gl.uniform1f(this.updateUniforms.damping, this.settings.damping);
+    gl.uniform1f(this.updateUniforms.dt, dt);
+
+    this.quad.draw();
+
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    this.currentIndex = targetIndex;
+  }
+
+  updateNormals() {
+    const gl = this.gl;
+    gl.useProgram(this.normalProgram);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.normalFramebuffer);
+    gl.viewport(0, 0, this.size, this.size);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.heightTextures[this.currentIndex]);
+    gl.uniform1i(this.normalUniforms.height, 0);
+    gl.uniform2f(this.normalUniforms.texel, this.texel[0], this.texel[1]);
+
+    this.quad.draw();
+
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  }
+
+  sampleProbe(x, z) {
+    const gl = this.gl;
+    gl.useProgram(this.probeProgram);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.probeFramebuffer);
+    gl.viewport(0, 0, 1, 1);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.heightTextures[this.currentIndex]);
+    gl.uniform1i(this.probeUniforms.height, 0);
+
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.normalTexture);
+    gl.uniform1i(this.probeUniforms.normal, 1);
+
+    gl.uniform2f(this.probeUniforms.center, x, z);
+
+    this.quad.draw();
+
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, this.probeReadBuffer);
+
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    const height = this.probeReadBuffer[0];
+    const normalX = this.probeReadBuffer[1] * 2 - 1;
+    const normalZ = this.probeReadBuffer[2] * 2 - 1;
+
+    return {
+      height,
+      normalX,
+      normalZ,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- set up a WebGL2 canvas app with GPU-driven water simulation and shader pipeline
- implement arcade boat physics, track mask/lap logic, and HUD overlay per the design doc
- add project entrypoint and documentation for running the prototype locally

## Testing
- not run (no automated test suite provided)

------
https://chatgpt.com/codex/tasks/task_b_68d1d206e3a4832eb2ca66193035d203