### PR TITLE
Fix shader loading paths for browser modules

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -15,10 +15,12 @@ import {
   ENVIRONMENT_SETTINGS,
 } from '../core/tuning.js';
 
-async function loadText(url) {
-  const response = await fetch(url);
+const SHADER_BASE_URL = new URL('../../shaders/', import.meta.url);
+
+async function loadText(name) {
+  const response = await fetch(new URL(name, SHADER_BASE_URL));
   if (!response.ok) {
-    throw new Error(`Failed to load shader: ${url}`);
+    throw new Error(`Failed to load shader: ${name}`);
   }
   return response.text();
 }
@@ -88,10 +90,10 @@ function buildBoatMesh() {
 export class Renderer {
   static async create(gl, track) {
     const [waterVert, waterFrag, boatVert, boatFrag] = await Promise.all([
-      loadText('shaders/water_surface.vert'),
-      loadText('shaders/water_surface.frag'),
-      loadText('shaders/boat.vert'),
-      loadText('shaders/boat.frag'),
+      loadText('water_surface.vert'),
+      loadText('water_surface.frag'),
+      loadText('boat.vert'),
+      loadText('boat.frag'),
     ]);
     return new Renderer(gl, track, {
       waterVert,

--- a/src/water/water.js
+++ b/src/water/water.js
@@ -7,10 +7,12 @@ import {
   assertExtensions,
 } from '../core/gl-utils.js';
 
-async function loadText(url) {
-  const response = await fetch(url);
+const SHADER_BASE_URL = new URL('../../shaders/', import.meta.url);
+
+async function loadText(name) {
+  const response = await fetch(new URL(name, SHADER_BASE_URL));
   if (!response.ok) {
-    throw new Error(`Failed to load shader: ${url}`);
+    throw new Error(`Failed to load shader: ${name}`);
   }
   return response.text();
 }
@@ -19,10 +21,10 @@ export class WaterSystem {
   static async create(gl, settings = WATER_SETTINGS) {
     assertExtensions(gl);
     const [dropSrc, updateSrc, normalSrc, probeSrc] = await Promise.all([
-      loadText('shaders/water_drop.frag'),
-      loadText('shaders/water_update.frag'),
-      loadText('shaders/water_normal.frag'),
-      loadText('shaders/probe.frag'),
+      loadText('water_drop.frag'),
+      loadText('water_update.frag'),
+      loadText('water_normal.frag'),
+      loadText('probe.frag'),
     ]);
     return new WaterSystem(gl, settings, {
       dropSrc,


### PR DESCRIPTION
## Summary
- resolve shader URLs relative to the module location so they load from the shared shaders directory
- ensure both the renderer and water system successfully fetch GLSL sources when served directly in the browser

## Testing
- not run (browser-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68d1da3a0804832eaf13a6c80ee56e8b